### PR TITLE
feat/fix: initial signup and login form display override even if ENABLE_LOGIN_FORM is false

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -557,7 +557,8 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
     has_users = Users.has_users()
 
     if WEBUI_AUTH:
-        if (
+        # Allow first-time admin creation even if ENABLE_LOGIN_FORM is false
+        if has_users and (
             not request.app.state.config.ENABLE_SIGNUP
             or not request.app.state.config.ENABLE_LOGIN_FORM
         ):

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -33,6 +33,10 @@
 
 	let ldapUsername = '';
 
+	// Check for URL parameter to force show login form
+	let forceShowForm = false;
+	let isFirstTimeSetup = false;
+
 	const querystringValue = (key) => {
 		const querystring = window.location.search;
 		const urlParams = new URLSearchParams(querystring);
@@ -161,10 +165,25 @@
 		loaded = true;
 		setLogoImage();
 
+		// Check for force form display parameter
+		forceShowForm = querystringValue('force_form') === 'true';
+		
+		// Check if this is first-time setup (no users exist)
+		isFirstTimeSetup = $config?.onboarding ?? false;
+
+		// Set mode appropriately - first-time setup should be signup
+		if (isFirstTimeSetup) {
+			mode = 'signup';
+		} else if ($config?.features.enable_ldap && !forceShowForm) {
+			mode = 'ldap';
+		} else {
+			mode = 'signin';
+		}
+
 		if (($config?.features.auth_trusted_header ?? false) || $config?.features.auth === false) {
 			await signInHandler();
 		} else {
-			onboarding = $config?.onboarding ?? false;
+			onboarding = isFirstTimeSetup;
 		}
 	});
 </script>
@@ -252,7 +271,7 @@
 									{/if}
 								</div>
 
-								{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
+								{#if $config?.features.enable_login_form || $config?.features.enable_ldap || forceShowForm || isFirstTimeSetup}
 									<div class="flex flex-col mt-4">
 										{#if mode === 'signup'}
 											<div class="mb-2">
@@ -343,7 +362,7 @@
 									</div>
 								{/if}
 								<div class="mt-5">
-									{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
+									{#if $config?.features.enable_login_form || $config?.features.enable_ldap || forceShowForm || isFirstTimeSetup}
 										{#if mode === 'ldap'}
 											<button
 												class="bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
@@ -392,7 +411,7 @@
 							{#if Object.keys($config?.oauth?.providers ?? {}).length > 0}
 								<div class="inline-flex items-center justify-center w-full">
 									<hr class="w-32 h-px my-4 border-0 dark:bg-gray-100/10 bg-gray-700/10" />
-									{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
+									{#if $config?.features.enable_login_form || $config?.features.enable_ldap || forceShowForm || isFirstTimeSetup}
 										<span
 											class="px-3 text-sm font-medium text-gray-900 dark:text-white bg-transparent"
 											>{$i18n.t('or')}</span


### PR DESCRIPTION
1) Force display of login form via ?force_form=true URL param even if ENABLE_LOGIN_FORM is false
2) Allow for the initial first user signup even if ENABLE_LOGIN_FORM is false

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [n/a] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

1) Allows forceful invocation of a Login Form via url query parameter in situation where the login form is normally disabled (and users rely on SSO/OAuth), but sometimes and admin still needs to log in manually using login/password. This is a frontend-only change not impacting security The /signin API always worked even if the form was disabled, so it was always possible to bypass the form and login via curl get a token and store it in the browser, just inconvenient.

2) Displays login form for the initial first user setup AND allow the /signup process to go through even if if the form is normally disabled by ENABLE_LOGIN_FORM=false. First admin user setup is essential for proper OpenWebUI initialization especially in scripted deployment scenarios e.g. to create its API key. Until now, the admin user could not be created (neither manually nor by a scripted curl request) if the login form was disabled via the env var which is a requirement for the normal go-forward operations. This is a backend change. 

### Changed

Changed login Form (username/password) and initial first-user sign-up form display conditions, allowing to see the form in some conditions even if the form is normally disabled by ENABLE_LOGIN_FORM=false. 

Changed /signup route to allow initial admin user creation even when ENABLE_LOGIN_FORM=false.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
